### PR TITLE
feat: add cluster mode support and harden registration validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,33 @@
 [![NPM version](https://img.shields.io/npm/v/@fastify/valkey-glide.svg?style=flat)](https://www.npmjs.com/package/@fastify/valkey-glide)
 [![neostandard javascript style](https://img.shields.io/badge/code_style-neostandard-brightgreen?style=flat)](https://github.com/neostandard/neostandard)
 
-Fastify Valkey connection plugin, with this you can share the same Valkey connection in every part of your server.
+Fastify plugin for sharing a
+[`@valkey/valkey-glide`](https://github.com/valkey-io/valkey-glide) client across
+your application.
 
-Using [`@valkey/valkey-glide`](https://github.com/valkey-io/valkey-glide) client under the hood.
-Valkey Glide is an open-source Valkey client library. it is one of the official client libraries for Valkey, and it supports all Valkey commands.
+## Install
+
+```sh
+npm i @fastify/valkey-glide
+```
 
 ### Compatibility
 
 | Plugin version | Fastify version |
-| ---------------|-----------------|
-|      `0.x`     |      `^5.x`     |
+| -------------- | --------------- |
+| `0.x`          | `^5.x`          |
 
-For Valkey and Redis DB compatibility look [here](https://github.com/valkey-io/valkey-glide?tab=readme-ov-file#supported-engine-versions)
+[Valkey GLIDE's supported engine versions](https://github.com/valkey-io/valkey-glide?tab=readme-ov-file#supported-engine-versions)
+determine Valkey and Redis compatibility.
 
 ## Usage
 
-Add it to your project with `register` and you are done!
+The plugin decorates Fastify with `fastify.valkey`.
 
-### Create a new Valkey Client
+### Plugin-managed client
 
-The `options` that you pass to `register` will be passed to the Valkey client.
+When `client` is omitted, the plugin creates and owns a standalone client by
+default:
 
 ```js
 import Fastify from 'fastify'
@@ -31,97 +38,47 @@ import fastifyValkey from '@fastify/valkey-glide'
 
 const fastify = Fastify()
 
-// create by specifying address
 fastify.register(fastifyValkey, {
-  addresses: [{ host: '127.0.0.1' }]
+  addresses: [{ host: '127.0.0.1', port: 6379 }]
 })
 
-// OR with more options
+fastify.get('/value/:key', async (request) => {
+  return fastify.valkey.get(request.params.key)
+})
+
+await fastify.listen({ port: 3000 })
+```
+
+For a cluster, use this registration instead. Cluster mode is not inferred from
+GLIDE options.
+
+```js
 fastify.register(fastifyValkey, {
-  addresses: [{ host: '127.0.0.1', port: 6379 }],
-  credentials: {username: "user1", password: "password"},
-  useTLS: true
+  clientMode: 'cluster',
+  addresses: [{ host: '127.0.0.1', port: 7000 }]
 })
 ```
 
-### Accessing the Valkey Client
+Other GLIDE configuration options are passed to the selected `createClient`
+method. Plugin-managed clients are closed when Fastify closes.
 
-Once you have registered your plugin, you can access the Valkey client via `fastify.valkey`.
+### Supplied client
 
-The client is automatically closed when the fastify instance is closed.
-
-```js
-import Fastify from 'fastify'
-import fastifyValkey from '@fastify/valkey-glide'
-
-const fastify = Fastify({ logger: true })
-
-fastify.register(fastifyValkey, {
-  addresses: [{ host: '127.0.0.1', port: 6379 }],
-})
-
-fastify.post('/foo', (request, reply) => {
-  fastify.valkey.set(request.body.key, request.body.value, (err) => {
-    reply.send(err || { status: 'ok' })
-  })
-})
-
-fastify.get('/foo', (request, reply) => {
-  fastify.valkey.get(request.query.key, (err, val) => {
-    reply.send(err || val)
-  })
-})
-
-try {
-  await fastify.listen({ port: 3000 })
-  console.log(`server listening on ${fastify.server.address().port}`)
-} catch (err) {
-  fastify.log.error(err)
-  process.exit(1)
-}
-```
-
-### Using an existing Valkey client
-
-You may also supply an existing *Valkey* client instance by passing an options
-object with the `client` property set to the instance. In this case,
-the client is not automatically closed when the Fastify instance is
-closed.
+Pass an existing `GlideClient` or `GlideClusterClient` with `client`. Do not
+combine `client` with `clientMode` or GLIDE client creation options.
 
 ```js
-import Fastify from 'fastify'
-import fastifyValkey from '@fastify/valkey-glide'
 import { GlideClient } from '@valkey/valkey-glide'
 
-const fastify = Fastify()
-
 const client = await GlideClient.createClient({
-  addresses: [{ host: 'localhost', port: 6379 }]
-})
-
-fastify.register(fastifyValkey, { client })
-```
-
-You can also supply a *Valkey Cluster* instance to the client:
-
-```js
-import Fastify from 'fastify'
-import fastifyValkey from '@fastify/valkey-glide'
-import { GlideClusterClient } from '@valkey/valkey-glide'
-
-const fastify = Fastify()
-
-const client = await GlideClusterClient.createClient({
   addresses: [{ host: '127.0.0.1', port: 6379 }]
 })
 
 fastify.register(fastifyValkey, { client })
 ```
 
-Note: by default, *@fastify/valkey-glide* will **not** automatically close the client
-connection when the Fastify server shuts down.
-
-To automatically close the client connection, set closeClient to true.
+A supplied client remains caller-owned and is not closed by default. Set
+`closeClient` to `true` to close it when Fastify closes:
 
 ```js
 fastify.register(fastifyValkey, {
@@ -132,64 +89,35 @@ fastify.register(fastifyValkey, {
 
 ## Registering multiple Valkey client instances
 
-By using the `namespace` option you can register multiple Valkey client instances.
+To register multiple clients in one Fastify context, give every registration a
+unique, non-empty `namespace`. `fastify.valkey` is then a map of clients instead
+of a client. Do not mix namespaced and unnamed registrations in the same context.
 
 ```js
 import Fastify from 'fastify'
 import fastifyValkey from '@fastify/valkey-glide'
-import { GlideClient } from '@valkey/valkey-glide'
 
 const fastify = Fastify()
 
-const valkey = await GlideClient.createClient({
-  addresses: [{ host: 'localhost', port: 6379 }]
-})
-
 fastify
   .register(fastifyValkey, {
-    addresses: [{ host: '127.0.0.1', port: 6380 }],
-    namespace: 'hello'
+    namespace: 'cache',
+    addresses: [{ host: '127.0.0.1', port: 6379 }]
   })
-
-fastify
   .register(fastifyValkey, {
-    client: valkey,
-    namespace: 'world'
+    namespace: 'sessions',
+    clientMode: 'cluster',
+    addresses: [{ host: '127.0.0.1', port: 7000 }]
   })
 
-// Here we will use the `hello` named instance
-fastify.post('/hello', (request, reply) => {
-  fastify.valkey['hello'].set(request.body.key, request.body.value, (err) => {
-    reply.send(err || { status: 'ok' })
-  })
+fastify.get('/cache/:key', async (request) => {
+  return fastify.valkey.cache.get(request.params.key)
 })
-
-fastify.get('/hello', (request, reply) => {
-  fastify.valkey.hello.get(request.query.key, (err, val) => {
-    reply.send(err || val)
-  })
-})
-
-// Here we will use the `world` named instance
-fastify.post('/world', (request, reply) => {
-  fastify.valkey.world.set(request.body.key, request.body.value, (err) => {
-    reply.send(err || { status: 'ok' })
-  })
-})
-
-fastify.get('/world', (request, reply) => {
-  fastify.valkey['world'].get(request.query.key, (err, val) => {
-    reply.send(err || val)
-  })
-})
-
-try {
-  await fastify.listen({ port: 3000 })
-} catch (err) {
-  fastify.log.error(err)
-  process.exit(1)
-}
 ```
+
+[Fastify encapsulation](https://fastify.dev/docs/latest/Reference/Encapsulation/)
+applies to child contexts. A child may inherit or shadow parent namespaces, or
+choose a different shape, without changing its parent or sibling contexts.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -1,32 +1,67 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const { GlideClient } = require('@valkey/valkey-glide')
+const { GlideClient, GlideClusterClient } = require('@valkey/valkey-glide')
+
+const namespaceMaps = new WeakSet()
 
 async function fastifyValkey (fastify, options) {
-  const { namespace, closeClient = false, ...valkeyOptions } = options
+  const { namespace, client: suppliedClient, closeClient, ...valkeyOptions } = options
 
-  let client = options.client || null
+  const hasSuppliedClient = suppliedClient !== undefined
+  let client = suppliedClient
+
+  delete valkeyOptions.prefix
+  delete valkeyOptions.logLevel
+  delete valkeyOptions.logSerializers
+
+  if (namespace !== undefined && (typeof namespace !== 'string' || namespace.length === 0)) {
+    throw new Error("'namespace' must be a non-empty string")
+  }
+
+  if (hasSuppliedClient && (suppliedClient === null || typeof suppliedClient !== 'object' || typeof suppliedClient.close !== 'function')) {
+    throw new Error("'client' must be an object with a close() method")
+  }
+
+  if (closeClient !== undefined && typeof closeClient !== 'boolean') {
+    throw new Error("'closeClient' must be a boolean")
+  }
+
+  if (hasSuppliedClient && Object.keys(valkeyOptions).length > 0) {
+    throw new Error("'client' cannot be combined with client creation options")
+  }
+
+  if (!hasSuppliedClient && closeClient !== undefined) {
+    throw new Error("'closeClient' can only be used with 'client'")
+  }
 
   if (namespace) {
-    if (!fastify.valkey) {
-      fastify.decorate('valkey', Object.create(null))
+    const hasOwnValkey = Object.hasOwn(fastify, 'valkey')
+
+    if (!hasOwnValkey) {
+      const parentNamespaceMap = namespaceMaps.has(fastify.valkey) ? fastify.valkey : null
+      const namespaceMap = Object.create(parentNamespaceMap)
+      namespaceMaps.add(namespaceMap)
+      fastify.decorate('valkey', namespaceMap)
+    } else if (!namespaceMaps.has(fastify.valkey)) {
+      throw new Error('@fastify/valkey-glide has already been registered; use a namespace for every client when registering multiple clients')
     }
-    if (fastify.valkey[namespace]) {
+
+    if (Object.hasOwn(fastify.valkey, namespace)) {
       throw new Error(`Valkey '${namespace}' instance namespace has already been registered`)
     }
 
-    const closeNamedInstance = (fastify) => { fastify.valkey[namespace].close() }
+    const closeNamedInstance = (_fastify) => { client.close() }
 
     client = await setupClient(fastify, client, closeClient, valkeyOptions, closeNamedInstance)
 
     fastify.valkey[namespace] = client
   } else {
-    if (fastify.valkey) {
-      throw new Error('@fastify/valkey has already been registered')
+    if (Object.hasOwn(fastify, 'valkey')) {
+      throw new Error('@fastify/valkey-glide has already been registered; use a namespace for every client when registering multiple clients')
     }
 
-    const close = (fastify) => { fastify.valkey.close() }
+    const close = (_fastify) => { client.close() }
 
     client = await setupClient(fastify, client, closeClient, valkeyOptions, close)
 
@@ -40,7 +75,15 @@ async function setupClient (fastify, client, closeClient, valkeyOptions, closeIn
       fastify.addHook('onClose', closeInstance)
     }
   } else {
-    client = await GlideClient.createClient(valkeyOptions)
+    const { clientMode = 'standalone', ...clientOptions } = valkeyOptions
+
+    if (clientMode === 'standalone') {
+      client = await GlideClient.createClient(clientOptions)
+    } else if (clientMode === 'cluster') {
+      client = await GlideClusterClient.createClient(clientOptions)
+    } else {
+      throw new Error("Invalid clientMode. Expected 'standalone' or 'cluster'")
+    }
 
     fastify.addHook('onClose', closeInstance)
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -129,7 +129,7 @@ test('Should accept custom valkey client that is already connected', async (t) =
 })
 
 test('Client should be close if closeClient is enabled', async (t) => {
-  t.plan(5)
+  t.plan(6)
   const fastify = Fastify()
   const { GlideClient } = require('@valkey/valkey-glide')
   const valkey = await GlideClient.createClient({ addresses: [{ host: '127.0.0.1', port: 6379 }] })
@@ -151,23 +151,22 @@ test('Client should be close if closeClient is enabled', async (t) => {
   const val2 = await fastify.valkey.get('closeClient enabled key2')
   t.assert.strictEqual(val2, 'closeClient enabled value2')
 
-  const originalClose = fastify.valkey.close
-  fastify.valkey.close = (callback) => {
+  const originalClose = valkey.close
+  valkey.close = () => {
     t.assert.ok('valkey client closed')
-    originalClose.call(fastify.valkey, callback)
+    originalClose.call(valkey)
   }
 
+  const replacementClient = { close: t.mock.fn() }
+  fastify.valkey = replacementClient
+
   await fastify.close()
-  try {
-    await valkey.get('closeClient enabled key1')
-    t.fail('Client should not work after being closed')
-  } catch (err) {
-    t.assert.ok('Should throw error when using closed client')
-  }
+  t.assert.strictEqual(replacementClient.close.mock.callCount(), 0)
+  await t.assert.rejects(valkey.get('closeClient enabled key1'))
 })
 
 test('Client should be close if closeClient is enabled, namespace', async (t) => {
-  t.plan(5)
+  t.plan(6)
   const fastify = Fastify()
   const { GlideClient } = require('@valkey/valkey-glide')
   const valkey = await GlideClient.createClient({ addresses: [{ host: '127.0.0.1', port: 6379 }] })
@@ -190,19 +189,18 @@ test('Client should be close if closeClient is enabled, namespace', async (t) =>
   const val2 = await fastify.valkey.close_client_enabled.get('closeClient enabled namespace key2')
   t.assert.strictEqual(val2, 'closeClient enabled namespace value2')
 
-  const originalClose = fastify.valkey.close_client_enabled.close
-  fastify.valkey.close_client_enabled.close = (callback) => {
+  const originalClose = valkey.close
+  valkey.close = () => {
     t.assert.ok('valkey client closed')
-    originalClose.call(fastify.valkey.close_client_enabled, callback)
+    originalClose.call(valkey)
   }
 
+  const replacementClient = { close: t.mock.fn() }
+  fastify.valkey.close_client_enabled = replacementClient
+
   await fastify.close()
-  try {
-    await valkey.close_client_enabled.get('closeClient enabled namespace key1')
-    t.fail('Client should not work after being closed')
-  } catch (err) {
-    t.assert.ok('Should throw error when using closed client')
-  }
+  t.assert.strictEqual(replacementClient.close.mock.callCount(), 0)
+  await t.assert.rejects(valkey.get('closeClient enabled namespace key1'))
 })
 
 test('Should throw when using duplicate connection namespaces', async (t) => {
@@ -226,6 +224,22 @@ test('Should throw when using duplicate connection namespaces', async (t) => {
   await t.assert.rejects(fastify.ready(), new Error(`Valkey '${namespace}' instance namespace has already been registered`))
 })
 
+test('Should throw when namespace is not a non-empty string', async (t) => {
+  t.plan(2)
+
+  for (const namespace of ['', 0]) {
+    const fastify = Fastify()
+
+    fastify.register(fastifyValkey, {
+      addresses: [{ host: '127.0.0.1', port: 6379 }],
+      namespace
+    })
+
+    await t.assert.rejects(fastify.ready(), new Error("'namespace' must be a non-empty string"))
+    await fastify.close()
+  }
+})
+
 test('Should throw when trying to register multiple instances without giving a namespace', async (t) => {
   t.plan(1)
 
@@ -240,7 +254,104 @@ test('Should throw when trying to register multiple instances without giving a n
       addresses: [{ host: '127.0.0.1', port: 6379 }],
     })
 
-  await t.assert.rejects(fastify.ready(), new Error('@fastify/valkey has already been registered'))
+  await t.assert.rejects(fastify.ready(), new Error('@fastify/valkey-glide has already been registered; use a namespace for every client when registering multiple clients'))
+})
+
+test('Should throw when adding a namespaced instance after an unnamed instance', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify
+    .register(fastifyValkey, {
+      addresses: [{ host: '127.0.0.1', port: 6379 }]
+    })
+    .register(fastifyValkey, {
+      addresses: [{ host: '127.0.0.1', port: 6379 }],
+      namespace: 'named'
+    })
+
+  await t.assert.rejects(fastify.ready(), new Error('@fastify/valkey-glide has already been registered; use a namespace for every client when registering multiple clients'))
+})
+
+test('Should throw when adding an unnamed instance after a namespaced instance', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify
+    .register(fastifyValkey, {
+      addresses: [{ host: '127.0.0.1', port: 6379 }],
+      namespace: 'named'
+    })
+    .register(fastifyValkey, {
+      addresses: [{ host: '127.0.0.1', port: 6379 }]
+    })
+
+  await t.assert.rejects(fastify.ready(), new Error('@fastify/valkey-glide has already been registered; use a namespace for every client when registering multiple clients'))
+})
+
+test('Should allow a child namespaced instance to shadow an inherited unnamed instance', async (t) => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  const parentClient = { close () {} }
+  const childClient = { close () {} }
+  let childInstance
+
+  fastify
+    .register(fastifyValkey, {
+      client: parentClient
+    })
+    .register(function (instance, _options, next) {
+      childInstance = instance
+      instance.register(fastifyValkey, {
+        client: childClient,
+        namespace: 'named'
+      })
+      next()
+    })
+
+  await fastify.ready()
+
+  t.assert.strictEqual(fastify.valkey, parentClient)
+  t.assert.notStrictEqual(childInstance.valkey, parentClient)
+  t.assert.strictEqual(childInstance.valkey.named, childClient)
+  t.assert.strictEqual(fastify.valkey.named, undefined)
+})
+
+test('Should allow a child unnamed instance to shadow an inherited namespace map', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  const parentClient = { close () {} }
+  const childClient = { close () {} }
+  let childInstance
+
+  fastify
+    .register(fastifyValkey, {
+      client: parentClient,
+      namespace: 'named'
+    })
+    .register(function (instance, _options, next) {
+      childInstance = instance
+      instance.register(fastifyValkey, {
+        client: childClient
+      })
+      next()
+    })
+
+  await fastify.ready()
+
+  t.assert.strictEqual(fastify.valkey.named, parentClient)
+  t.assert.strictEqual(childInstance.valkey, childClient)
+  t.assert.strictEqual(childInstance.valkey.named, undefined)
 })
 
 test('Should not throw within different contexts with same namespace', async (t) => {
@@ -274,6 +385,52 @@ test('Should not throw within different contexts with same namespace', async (t)
   t.assert.ok(fastify)
 })
 
+test('Should keep child namespace registrations encapsulated', async (t) => {
+  t.plan(7)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  const parentClient = { close () {} }
+  const parentSharedClient = { close () {} }
+  const childClient = { close () {} }
+  const childSharedClient = { close () {} }
+  let childInstance
+
+  fastify
+    .register(fastifyValkey, {
+      client: parentClient,
+      namespace: 'parent'
+    })
+    .register(fastifyValkey, {
+      client: parentSharedClient,
+      namespace: 'shared'
+    })
+    .register(function (instance, _options, next) {
+      childInstance = instance
+      instance
+        .register(fastifyValkey, {
+          client: childClient,
+          namespace: 'child'
+        })
+        .register(fastifyValkey, {
+          client: childSharedClient,
+          namespace: 'shared'
+        })
+      next()
+    })
+
+  await fastify.ready()
+
+  t.assert.notStrictEqual(childInstance.valkey, fastify.valkey)
+  t.assert.strictEqual(fastify.valkey.parent, parentClient)
+  t.assert.strictEqual(fastify.valkey.shared, parentSharedClient)
+  t.assert.strictEqual(fastify.valkey.child, undefined)
+  t.assert.strictEqual(childInstance.valkey.parent, parentClient)
+  t.assert.strictEqual(childInstance.valkey.child, childClient)
+  t.assert.strictEqual(childInstance.valkey.shared, childSharedClient)
+})
+
 test('Should throw when trying to connect on an invalid host', async (t) => {
   t.plan(1)
 
@@ -288,6 +445,128 @@ test('Should throw when trying to connect on an invalid host', async (t) => {
   })
 
   await t.assert.rejects(fastify.ready())
+})
+
+test("Should create and close a cluster client when clientMode is 'cluster'", async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  const { GlideClusterClient } = require('@valkey/valkey-glide')
+  const fakeClient = {
+    close: t.mock.fn()
+  }
+
+  t.mock.method(GlideClusterClient, 'createClient', async (options) => {
+    t.assert.deepStrictEqual(options, {
+      addresses: [{ host: '127.0.0.1', port: 6379 }],
+      periodicChecks: 'disabled'
+    })
+    return fakeClient
+  })
+
+  fastify.register(fastifyValkey, {
+    clientMode: 'cluster',
+    addresses: [{ host: '127.0.0.1', port: 6379 }],
+    periodicChecks: 'disabled'
+  })
+
+  await fastify.ready()
+  t.assert.strictEqual(fastify.valkey, fakeClient)
+  await fastify.close()
+  t.assert.strictEqual(fakeClient.close.mock.callCount(), 1)
+})
+
+test('Should throw when clientMode is invalid', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(fastifyValkey, {
+    clientMode: 'invalid_mode',
+    addresses: [{ host: '127.0.0.1', port: 6379 }]
+  })
+
+  await t.assert.rejects(fastify.ready(), new Error("Invalid clientMode. Expected 'standalone' or 'cluster'"))
+})
+
+test('Should throw when client creation options are used with an existing client', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(fastifyValkey, {
+    client: { close () {} },
+    clientMode: 'cluster'
+  })
+
+  await t.assert.rejects(fastify.ready(), new Error("'client' cannot be combined with client creation options"))
+})
+
+test('Should allow Fastify registration options with an existing client', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+  const client = { close () {} }
+
+  fastify.register(fastifyValkey, {
+    client,
+    prefix: '/ignored',
+    logLevel: 'debug',
+    logSerializers: {
+      valkey: String
+    }
+  })
+
+  await fastify.ready()
+  t.assert.strictEqual(fastify.valkey, client)
+})
+
+test('Should throw when client does not provide a close method', async (t) => {
+  const invalidClients = [null, false, 0, 'client', {}]
+  t.plan(invalidClients.length)
+
+  for (const client of invalidClients) {
+    const fastify = Fastify()
+
+    fastify.register(fastifyValkey, { client })
+
+    await t.assert.rejects(fastify.ready(), new Error("'client' must be an object with a close() method"))
+    await fastify.close()
+  }
+})
+
+test('Should throw when closeClient is not a boolean', async (t) => {
+  const invalidCloseClientValues = ['true', 1, null]
+  t.plan(invalidCloseClientValues.length)
+
+  for (const closeClient of invalidCloseClientValues) {
+    const fastify = Fastify()
+
+    fastify.register(fastifyValkey, {
+      client: { close () {} },
+      closeClient
+    })
+
+    await t.assert.rejects(fastify.ready(), new Error("'closeClient' must be a boolean"))
+    await fastify.close()
+  }
+})
+
+test('Should throw when closeClient is used with a managed client', async (t) => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(fastifyValkey, {
+    addresses: [{ host: '127.0.0.1', port: 6379 }],
+    closeClient: false
+  })
+
+  await t.assert.rejects(fastify.ready(), new Error("'closeClient' can only be used with 'client'"))
 })
 
 test('Should be able to register multiple namespaced @fastify/valkey instances', async t => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,7 +1,11 @@
-import { FastifyPluginCallback } from 'fastify'
-import { GlideClient, GlideClusterClient, GlideClientConfiguration, } from '@valkey/valkey-glide'
+import { FastifyPluginAsync } from 'fastify'
+import { GlideClient, GlideClusterClient, GlideClientConfiguration, GlideClusterClientConfiguration, } from '@valkey/valkey-glide'
 
-type FastifyValkeyPluginType = FastifyPluginCallback<fastifyValkey.FastifyValkeyPluginOptions>
+type FastifyValkeyPluginType = FastifyPluginAsync<fastifyValkey.FastifyValkeyPluginOptions>
+
+// Keep option variants mutually exclusive as GLIDE adds configuration keys.
+type UnionKeys<T> = T extends unknown ? keyof T : never
+type StrictUnion<T, TAll = T> = T extends unknown ? T & Partial<Record<Exclude<UnionKeys<TAll>, keyof T>, never>> : never
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -19,7 +23,7 @@ declare namespace fastifyValkey {
 
   export type FastifyValkey = FastifyValkeyNamespacedInstance & ValkeyClient
 
-  export type FastifyValkeyPluginOptions =
+  export type FastifyValkeyPluginOptions = StrictUnion<
     {
       client: ValkeyClient;
       namespace?: string;
@@ -29,7 +33,15 @@ declare namespace fastifyValkey {
       closeClient?: boolean;
     } | ({
       namespace?: string;
-    } & GlideClientConfiguration)
+      /**
+       * @default 'standalone'
+       */
+      clientMode?: 'standalone';
+    } & GlideClientConfiguration) | ({
+      namespace?: string;
+      clientMode: 'cluster';
+    } & GlideClusterClientConfiguration)
+  >
   export const fastifyValkey: FastifyValkeyPluginType
   export { fastifyValkey as default }
 }

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -4,23 +4,106 @@ import { expect } from 'tstyche'
 import fastifyValkey, { FastifyValkey, FastifyValkeyPluginOptions, FastifyValkeyNamespacedInstance, } from '.'
 
 const app:FastifyInstance = Fastify()
+const directApp:FastifyInstance = Fastify()
+const namespacedApp:FastifyInstance = Fastify()
+const registerOptionsApp:FastifyInstance = Fastify()
 const valkey = {} as GlideClient
 const valkeyCluster = {} as GlideClusterClient
 app.register(fastifyValkey, { addresses: [{ host: '127.0.0.1', port: 6379 }] })
 
-app.register(fastifyValkey, {
+const pluginResult = fastifyValkey(directApp, {
+  addresses: [{ host: '127.0.0.1', port: 6379 }]
+})
+expect(pluginResult).type.toBe<Promise<void>>()
+
+namespacedApp.register(fastifyValkey, {
   client: valkey,
   closeClient: true,
   namespace: 'one'
 })
 
-app.register(fastifyValkey, {
+namespacedApp.register(fastifyValkey, {
   namespace: 'two',
   addresses: [{ host: '127.0.0.1', port: 6379 }]
 })
 
+namespacedApp.register(fastifyValkey, {
+  namespace: 'cluster',
+  clientMode: 'cluster',
+  addresses: [{ host: '127.0.0.1', port: 6379 }],
+  periodicChecks: 'enabledDefaultConfigs'
+})
+
+registerOptionsApp.register(fastifyValkey, {
+  client: valkey,
+  prefix: '/ignored',
+  logLevel: 'debug',
+  logSerializers: {
+    valkey: String
+  }
+})
+
 expect<FastifyValkeyPluginOptions>().type.toBeAssignableFrom({
   client: valkeyCluster
+})
+
+expect<FastifyValkeyPluginOptions>().type.toBeAssignableFrom({
+  clientMode: 'cluster' as const,
+  addresses: [{ host: '127.0.0.1', port: 6379 }],
+  periodicChecks: 'disabled' as const
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  clientMode: 'standalone' as const,
+  addresses: [{ host: '127.0.0.1', port: 6379 }],
+  periodicChecks: 'disabled' as const
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  addresses: [{ host: '127.0.0.1', port: 6379 }],
+  periodicChecks: 'disabled' as const
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  addresses: [{ host: '127.0.0.1', port: 6379 }],
+  recoveryRequestsQueueSize: 100
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  addresses: [{ host: '127.0.0.1', port: 6379 }],
+  advancedConfiguration: {
+    refreshTopologyFromInitialNodes: true
+  }
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  clientMode: 'invalid',
+  addresses: [{ host: '127.0.0.1', port: 6379 }]
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  client: valkeyCluster,
+  clientMode: 'cluster' as const,
+  addresses: [{ host: '127.0.0.1', port: 6379 }]
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  client: valkey,
+  addresses: [{ host: '127.0.0.1', port: 6379 }]
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  client: null
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  client: valkey,
+  closeClient: 'true'
+})
+
+expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
+  addresses: [{ host: '127.0.0.1', port: 6379 }],
+  closeClient: false
 })
 
 expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
@@ -32,10 +115,12 @@ expect<FastifyValkeyPluginOptions>().type.not.toBeAssignableFrom({
 app.after(() => {
   expect(app.valkey).type.toBeAssignableTo<GlideClient | GlideClusterClient>()
   expect(app.valkey).type.toBe<FastifyValkey>()
+})
 
-  expect(app.valkey).type.toBeAssignableTo<FastifyValkeyNamespacedInstance>()
-  expect(app.valkey.one).type.toBe<
+namespacedApp.after(() => {
+  expect(namespacedApp.valkey).type.toBeAssignableTo<FastifyValkeyNamespacedInstance>()
+  expect(namespacedApp.valkey.one).type.toBe<
     GlideClient | GlideClusterClient | undefined
   >()
-  expect(app.valkey.two).type.toBe<GlideClient | GlideClusterClient | undefined>()
+  expect(namespacedApp.valkey.two).type.toBe<GlideClient | GlideClusterClient | undefined>()
 })


### PR DESCRIPTION
## Summary

Adds explicit support for plugin-managed Valkey Cluster clients while preserving standalone mode as the default.

The change also tightens configuration validation, aligns multiple-client behavior with Fastify encapsulation, and clarifies client ownership.

## Why

The managed-client path previously always created a `GlideClient`, so the plugin could not create a `GlideClusterClient`.

Multiple registrations also had order-dependent behavior: mixing unnamed and namespaced clients could produce different `fastify.valkey` shapes depending on registration order. Misconfigured supplied clients and lifecycle options could likewise be accepted or silently ignored.
